### PR TITLE
feat: 增加参数指定滚动容器

### DIFF
--- a/src/ts/markdown/outlineRender.ts
+++ b/src/ts/markdown/outlineRender.ts
@@ -1,7 +1,7 @@
 import {hasClosestByHeadings} from "../util/hasClosestByHeadings";
 import {mathRender} from "./mathRender";
 
-export const outlineRender = (contentElement: HTMLElement, targetElement: Element, vditor?: IVditor) => {
+export const outlineRender = (contentElement: HTMLElement, targetElement: Element, vditor?: IVditor, scrollElement?: HTMLElement) => {
     let tocHTML = "";
     const ids: string[] = [];
     Array.from(contentElement.children).forEach((item: HTMLElement, index: number) => {
@@ -95,7 +95,11 @@ export const outlineRender = (contentElement: HTMLElement, targetElement: Elemen
                         }
                     }
                 } else {
-                    window.scrollTo(window.scrollX, idElement.offsetTop);
+                    if (scrollElement) {
+                        scrollElement.scrollTo(window.scrollX, idElement.offsetTop - scrollElement.offsetTop);
+                    } else {
+                        window.scrollTo(window.scrollX, idElement.offsetTop);
+                    }
                 }
                 break;
             }


### PR DESCRIPTION
### 描述
目前预览点击大纲是滚动 `window`,如果 `vditor` 放在某个可滚动的容器中，就会导致点击大纲跳转不到对应的内容。

### 做了什么
增加一个可选参数 `scrollElement` 来指定滚动容器。

### 测试
已自测。